### PR TITLE
Do not load GFS modules

### DIFF
--- a/scripts/gda/archive.sh
+++ b/scripts/gda/archive.sh
@@ -123,8 +123,8 @@ echo "Loading modules"
 set +x
 module use "${HOMEgda}/gda/modulefiles"
 module load archive.wcoss2
-set -x
 status=$?
+set -x
 
 if [[ $status -ne 0 ]]; then
   if [[ ${do_mail:-NO} == "YES" ]]; then

--- a/scripts/gda/archive.sh
+++ b/scripts/gda/archive.sh
@@ -118,8 +118,12 @@ export SYNC_BACK=${SYNC_BACK:-"0"}
 export backchk="NO"
 export machs=${machs:-"all"}
 
-# Initialize modules
-. $HOMEgfs/ush/load_fv3gfs_modules.sh
+# Load modules
+echo "Loading modules"
+set +x
+module use "${HOMEgda}/gda/modulefiles"
+module load archive.wcoss2
+set -x
 status=$?
 
 if [[ $status -ne 0 ]]; then

--- a/scripts/gda/dump.sh
+++ b/scripts/gda/dump.sh
@@ -18,8 +18,8 @@ set +x
 echo "Loading modules"
 module use "${HOMEgda}/gda/modulefiles"
 module load archive.wcoss2
-set -x
 status=$?
+set -x
 
 if [[ $status -ne 0 ]]; then
   echo "FATAL ERROR: Unable to load modules!"

--- a/scripts/gda/dump.sh
+++ b/scripts/gda/dump.sh
@@ -3,8 +3,6 @@ set -x
 
 ###############################################################
 # Source FV3GFS workflow modules
-source $HOMEgfs/ush/load_fv3gfs_modules.sh
-status=$?
 [[ $status -ne 0 ]] && exit $status
 
 ###############################################################
@@ -15,6 +13,19 @@ for config in $configs; do
     status=$?
     [[ $status -ne 0 ]] && exit $status
 done
+
+# Load modules
+set +x
+echo "Loading modules"
+module use "${HOMEgda}/gda/modulefiles"
+module load archive.wcoss2
+set -x
+status=$?
+
+if [[ $status -ne 0 ]]; then
+  echo "FATAL ERROR: Unable to load modules!"
+  exit $status
+fi
 
 ##############################################
 # Obtain unique process id (pid) and make temp directory

--- a/scripts/gda/dump.sh
+++ b/scripts/gda/dump.sh
@@ -3,7 +3,6 @@ set -x
 
 ###############################################################
 # Source FV3GFS workflow modules
-[[ $status -ne 0 ]] && exit $status
 
 ###############################################################
 # Source relevant configs

--- a/scripts/gda/gda.xml
+++ b/scripts/gda/gda.xml
@@ -39,7 +39,7 @@
   <cycledef>202306200000 202701011800 06:00:00</cycledef>
 
   <task name="gda.gfs" maxtries="2" cycledefs="gfs">
-        <command>sh -c ' source $HOMEgfs/ush/load_fv3gfs_modules.sh exclusive ; module list ; source $EXPDIR/config.base ; source $EXPDIR/config.dumparch ; $EXPDIR/dump.sh'</command>
+        <command>sh -c '$EXPDIR/dump.sh'</command>
         <queue>&QUEUESERV;</queue>
         <account>&PROJ;</account>
         <jobname>gda.gfs_<cyclestr>@Y@m@d@H</cyclestr></jobname>
@@ -71,7 +71,7 @@
   </task>
 
   <task name="gda.gdas" maxtries="2" cycledefs="gdas">
-        <command>sh -c ' source $HOMEgfs/ush/load_fv3gfs_modules.sh exclusive ; module list ; source $EXPDIR/config.base ; source $EXPDIR/config.dumparch ; $EXPDIR/dump.sh'</command>
+        <command>sh -c '$EXPDIR/dump.sh'</command>
         <queue>&QUEUESERV;</queue>
         <account>&PROJ;</account>
         <jobname>gda.gdas_<cyclestr>@Y@m@d@H</cyclestr></jobname>


### PR DESCRIPTION
This removes all references to `load_fv3gfs_modules.sh` from the GDA scripts and instead relies on the GDA's modules.  This is needed to get the RTOFS data to sync.