### PR TITLE
Update the GFS production version to 16.3.28

### DIFF
--- a/scripts/gda/config.dumparch
+++ b/scripts/gda/config.dumparch
@@ -29,7 +29,7 @@ fi
 # Set account
 export USER=${USER:-emc.global}
 
-export gfs_ver="v16.3.27"
+export gfs_ver="v16.3.28"
 
 # Set GDA paths
 export DMPDIR="/lfs/h2/emc/dump/noscrub/dump"
@@ -64,7 +64,7 @@ export SUP_BACK=0
 
 #export DALERT="YES"
 export DALERT="NO"
-export DMPCPCMD="rsync -azvp --checksum"
+export DMPCPCMD="rsync -avp --checksum"
 export DMPSUP="YES"
 export DMPTRAN="YES"
 

--- a/scripts/gda/gda.xml
+++ b/scripts/gda/gda.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE workflow [
 
-  <!ENTITY gfs_ver "v16.3.27">
+  <!ENTITY gfs_ver "v16.3.28">
   <!ENTITY gfs_ver_com "v16.3">
   <!ENTITY obsproc_ver "v1.2">
   <!ENTITY rtofs_ver "v2.5">


### PR DESCRIPTION
This update was performed on 10/27/2025 to the production GDA scripts.  This PR brings the updates into the repository.  I removed the `-z` option for `rsync` as this compression step actually makes for a slower transfer.

FYI @nicholasesposito @AshleyStanfield-NOAA as I mentioned last week, any time the GFS version increments, this will break the GDA scripts. This update was required to fix the GDA. After updating the script and XML, the failed jobs were relauched with `rocotoboot`. This should probably be improved to simply check for the newest `/lfs/h1/ops/prod/gfs.v*` directory. We only need the operational GFS repository to get the `obsproc` version and load modules. The version number and the modules needed for the GDA could probably be created in the `glopara-cm-tools` repository.