### PR TITLE
Update production crontab (20260204)

### DIFF
--- a/crontab/production.crontab
+++ b/crontab/production.crontab
@@ -58,10 +58,10 @@ MAILTO="jessica.meixner@noaa.gov"
 MAILTO="nicholas.esposito@noaa.gov"
 
 # These move ocean data between the prod and dev machines using rsync on a real time basis
-*/15 * * * * /opt/pbs/bin/qsub -v year=`date -d "yesterday" +\%Y`,month=`date -d "yesterday" +\%m`,start_day=`date -d "yesterday" +\%d`,end_day=`date -d "yesterday" +\%d` < /u/emc.global/transfer_rsync_oceantoocean_thismachine.sh
-*/15 * * * * /opt/pbs/bin/qsub -v year=`date -d "today" +\%Y`,month=`date -d "today" +\%m`,start_day=`date -d "today" +\%d`,end_day=`date -d "today" +\%d` < /u/emc.global/transfer_rsync_oceantoocean_thismachine.sh
-*/15 * * * * /opt/pbs/bin/qsub -v year=`date -d "yesterday" +\%Y`,month=`date -d "yesterday" +\%m`,start_day=`date -d "yesterday" +\%d`,end_day=`date -d "yesterday" +\%d` < /u/emc.global/transfer_rsync_ocean_DtoC.sh
-*/15 * * * * /opt/pbs/bin/qsub -v year=`date -d "today" +\%Y`,month=`date -d "today" +\%m`,start_day=`date -d "today" +\%d`,end_day=`date -d "today" +\%d` < /u/emc.global/transfer_rsync_ocean_DtoC.sh
+#*/15 * * * * /opt/pbs/bin/qsub -v year=`date -d "yesterday" +\%Y`,month=`date -d "yesterday" +\%m`,start_day=`date -d "yesterday" +\%d`,end_day=`date -d "yesterday" +\%d` < /u/emc.global/transfer_rsync_oceantoocean_thismachine.sh
+#*/15 * * * * /opt/pbs/bin/qsub -v year=`date -d "today" +\%Y`,month=`date -d "today" +\%m`,start_day=`date -d "today" +\%d`,end_day=`date -d "today" +\%d` < /u/emc.global/transfer_rsync_oceantoocean_thismachine.sh
+#*/15 * * * * /opt/pbs/bin/qsub -v year=`date -d "yesterday" +\%Y`,month=`date -d "yesterday" +\%m`,start_day=`date -d "yesterday" +\%d`,end_day=`date -d "yesterday" +\%d` < /u/emc.global/transfer_rsync_ocean_DtoC.sh
+#*/15 * * * * /opt/pbs/bin/qsub -v year=`date -d "today" +\%Y`,month=`date -d "today" +\%m`,start_day=`date -d "today" +\%d`,end_day=`date -d "today" +\%d` < /u/emc.global/transfer_rsync_ocean_DtoC.sh
 
 # For Mindo, sent on 20251224
 #15 * * * * /opt/pbs/bin/qsub -v year=`date -d "today" +\%Y`,month=`date -d "today" +\%m`,start_day=`date -d "today" +\%d`,end_day=`date -d "today" +\%d` < /u/emc.global/transfer_rsync_Mindo.sh

--- a/crontab/production.crontab
+++ b/crontab/production.crontab
@@ -1,22 +1,16 @@
 #######################
 SHELL=/bin/bash -l
-#SHELL=/bin/bash
 
-############################################################################
-# ROCOTO 4 CI
-######################
-# DISABLED; all CI should be run manually on WCOSS2
-#*/5 * * * * /lfs/h2/emc/global/noscrub/emc.global/ci/run_rocoto.sh > /lfs/h2/emc/global/noscrub/emc.global/ci/run_rocoto.log 2>&1
+MAILTO="jessica.meixner@noaa.gov,david.huber@noaa.gov,nicholas.esposito@noaa.gov"
 
 ############################################################################
 # Data syncs - syndat & verif
 ######################
-0 22 * * * /lfs/h2/emc/global/noscrub/emc.global/scripts/DATA/submit_sync_data.sh > /lfs/h2/emc/stmp/emc.global/submit_sync_data.log 2>&1
+#0 22 * * * /lfs/h2/emc/global/noscrub/emc.global/scripts/DATA/submit_sync_data.sh > /lfs/h2/emc/stmp/emc.global/submit_sync_data.log 2>&1
 
 ############################################################################
 #### GLOBAL DUMP ARCHIVE ####
 MAILTO="jessica.meixner@noaa.gov,david.huber@noaa.gov,nicholas.esposito@noaa.gov,ashley.stanfield@noaa.gov"
-
 
 ######################
 # Main GDA job
@@ -35,22 +29,22 @@ MAILTO="jessica.meixner@noaa.gov,david.huber@noaa.gov,nicholas.esposito@noaa.gov
 #################################
 # POC: Jessica Meixner, Cathy Thomas and Ruiyu Sun
 #################### retrotestgfs01 ####################
-MAILTO="jessica.meixner@noaa.gov,catherine.thomas@noaa.gov,ruiyu.sun@noaa.gov,jiande.wang@noaa.gov,christian.boyer@noaa.gov"
+MAILTO="jessica.meixner@noaa.gov,catherine.thomas@noaa.gov,ruiyu.sun@noaa.gov,jiande.wang@noaa.gov,christian.boyer@noaa.gov,jiande.wang@noaa.gov"
 
+#realtime
 #*/5 * * * * /apps/ops/test/nco/core/rocoto.v1.3.5/bin/rocotorun -d /lfs/h2/emc/gfstemp/emc.global/expdir/retrov17_01_realtime/retrov17_01_realtime.db -w /lfs/h2/emc/gfstemp/emc.global/expdir/retrov17_01_realtime/retrov17_01_realtime.xml
 
-#*/5 * * * * /apps/ops/test/nco/core/rocoto.v1.3.5/bin/rocotorun -d /lfs/h2/emc/gfstemp/emc.global/expdir/retrov17_01_stream2/retrov17_01_stream2.db -w /lfs/h2/emc/gfstemp/emc.global/expdir/retrov17_01_stream2/retrov17_01_stream2.xml
-
+#retrostreams
+#*/4 * * * * /apps/ops/test/nco/core/rocoto.v1.3.5/bin/rocotorun -d /lfs/h2/emc/gfstemp/emc.global/expdir/retrov17_01_stream2/retrov17_01_stream2.db -w /lfs/h2/emc/gfstemp/emc.global/expdir/retrov17_01_stream2/retrov17_01_stream2.xml
 #*/5 * * * * /apps/ops/test/nco/core/rocoto.v1.3.5/bin/rocotorun -d /lfs/h2/emc/gfstemp/emc.global/expdir/retrov17_01_stream3/retrov17_01_stream3.db -w /lfs/h2/emc/gfstemp/emc.global/expdir/retrov17_01_stream3/retrov17_01_stream3.xml
 
-#MAILTO="jessica.meixner@noaa.gov,catherine.thomas@noaa.gov,ruiyu.sun@noaa.gov"
-#*/5 * * * * /apps/ops/test/nco/core/rocoto.v1.3.5/bin/rocotorun -d /lfs/h2/emc/gfstemp/emc.global/expdir/test_repro_stream2/test_repro_stream2.db -w /lfs/h2/emc/gfstemp/emc.global/expdir/test_repro_stream2/test_repro_stream2.xml
-
+#Experiment monitoring script
 
 MAILTO="catherine.thomas@noaa.gov"
 #0 */12 * * * /lfs/h2/emc/gfstemp/emc.global/scripts/stat_exp.sh retrov17_01_realtime >/dev/null
 #0 */12 * * * /lfs/h2/emc/gfstemp/emc.global/scripts/stat_exp.sh retrov17_01_stream2 >/dev/null
 #0 */12 * * * /lfs/h2/emc/gfstemp/emc.global/scripts/stat_exp.sh retrov17_01_stream3 >/dev/null
+
 MAILTO="jessica.meixner@noaa.gov"
 #0 5 * * * /opt/pbs/bin/qsub < /lfs/h2/emc/gfstemp/emc.global/scripts/evsdownload/download4evs_realtime.sh
 #0 1 * * * /opt/pbs/bin/qsub < /lfs/h2/emc/gfstemp/emc.global/scripts/evsdownload/download4evs_stream1a.sh
@@ -60,20 +54,21 @@ MAILTO="jessica.meixner@noaa.gov"
 #0 4 * * * /opt/pbs/bin/qsub < /lfs/h2/emc/gfstemp/emc.global/scripts/evsdownload/download4evs_stream4.sh
 
 
-
-#################################################################
-
-##### Sending ocean data to current production (Dogwood) from current dev (Cactus) 11/20/25 - Nick Esposito
+##### Sending ocean data to current production (Cactus) from current dev (Dogwood) 2/4/2026 - David Huber
 MAILTO="nicholas.esposito@noaa.gov"
 
 # These move ocean data between the prod and dev machines using rsync on a real time basis
-#*/15 * * * * /opt/pbs/bin/qsub -v year=`date -d "yesterday" +\%Y`,month=`date -d "yesterday" +\%m`,start_day=`date -d "yesterday" +\%d`,end_day=`date -d "yesterday" +\%d` < /u/emc.global/transfer_rsync_oceantoocean_thismachine.sh
-#*/15 * * * * /opt/pbs/bin/qsub -v year=`date -d "today" +\%Y`,month=`date -d "today" +\%m`,start_day=`date -d "today" +\%d`,end_day=`date -d "today" +\%d` < /u/emc.global/transfer_rsync_oceantoocean_thismachine.sh
-#*/15 * * * * /opt/pbs/bin/qsub -v year=`date -d "yesterday" +\%Y`,month=`date -d "yesterday" +\%m`,start_day=`date -d "yesterday" +\%d`,end_day=`date -d "yesterday" +\%d` < /u/emc.global/transfer_rsync_ocean_DtoC.sh
-#*/15 * * * * /opt/pbs/bin/qsub -v year=`date -d "today" +\%Y`,month=`date -d "today" +\%m`,start_day=`date -d "today" +\%d`,end_day=`date -d "today" +\%d` < /u/emc.global/transfer_rsync_ocean_DtoC.sh
+*/15 * * * * /opt/pbs/bin/qsub -v year=`date -d "yesterday" +\%Y`,month=`date -d "yesterday" +\%m`,start_day=`date -d "yesterday" +\%d`,end_day=`date -d "yesterday" +\%d` < /u/emc.global/transfer_rsync_oceantoocean_thismachine.sh
+*/15 * * * * /opt/pbs/bin/qsub -v year=`date -d "today" +\%Y`,month=`date -d "today" +\%m`,start_day=`date -d "today" +\%d`,end_day=`date -d "today" +\%d` < /u/emc.global/transfer_rsync_oceantoocean_thismachine.sh
+*/15 * * * * /opt/pbs/bin/qsub -v year=`date -d "yesterday" +\%Y`,month=`date -d "yesterday" +\%m`,start_day=`date -d "yesterday" +\%d`,end_day=`date -d "yesterday" +\%d` < /u/emc.global/transfer_rsync_ocean_DtoC.sh
+*/15 * * * * /opt/pbs/bin/qsub -v year=`date -d "today" +\%Y`,month=`date -d "today" +\%m`,start_day=`date -d "today" +\%d`,end_day=`date -d "today" +\%d` < /u/emc.global/transfer_rsync_ocean_DtoC.sh
 
 # For Mindo, sent on 20251224
 #15 * * * * /opt/pbs/bin/qsub -v year=`date -d "today" +\%Y`,month=`date -d "today" +\%m`,start_day=`date -d "today" +\%d`,end_day=`date -d "today" +\%d` < /u/emc.global/transfer_rsync_Mindo.sh
 
 # The next script is for rsyncing scripts between the prod and dev machines, a month at a time.
 #16 * * * * /opt/pbs/bin/qsub -v year=2022,month=08,start_day=14,end_day=31 < /u/emc.global/transfer_rsync_allfilesmonth.sh
+
+# Check for production version of the GFS
+MAILTO="nicholas.esposito@noaa.gov,david.huber@noaa.gov,ashley.stanfield@noaa.gov"
+0 */12 * * * ls -d /lfs/h1/ops/prod/packages/gfs.*


### PR DESCRIPTION
These are the suggested updates to the production crontab. The suggested updates to the development crontab are below and reflect a reconciliation between production and development crontabs. The current development crontab is attached for reference. I will update the diffs below after reviews of the production crontab are complete.

[development.crontab.txt](https://github.com/user-attachments/files/25074759/development.crontab.txt)
```diff
diff --git a/crontab.dev b/crontab.dev
index ed49c7d..0149f94 100644
--- a/crontab.dev
+++ b/crontab.dev
@@ -1,14 +1,7 @@
-########################
-## EMC.GLOBAL CRONTAB ##
-########################
+#######################
 SHELL=/bin/bash -l
 
-############################################################################
-# RETRO CRONS
-############################################################################
-####NEEDS UPDATE MAILTO="kate.friedman@noaa.gov"
 MAILTO="jessica.meixner@noaa.gov,david.huber@noaa.gov,nicholas.esposito@noaa.gov"
-#################### test ####################
 
 ############################################################################
 # Data syncs - syndat & verif
@@ -17,9 +10,7 @@ MAILTO="jessica.meixner@noaa.gov,david.huber@noaa.gov,nicholas.esposito@noaa.gov
 
 ############################################################################
 #### GLOBAL DUMP ARCHIVE ####
-####NEEDS UPDATE MAILTO="kate.friedman@noaa.gov"
-
-#*/15 * * * * /lfs/h2/emc/global/noscrub/emc.global/scripts/GFS_VERSION/gfs_version.sh > /lfs/h2/emc/global/noscrub/emc.global/scripts/GFS_VERSION/gfs_version.log 2>&1
+MAILTO="jessica.meixner@noaa.gov,david.huber@noaa.gov,nicholas.esposito@noaa.gov,ashley.stanfield@noaa.gov"
 
 ######################
 # Main GDA job
@@ -31,10 +22,13 @@ MAILTO="jessica.meixner@noaa.gov,david.huber@noaa.gov,nicholas.esposito@noaa.gov
 ######################
 # Main dump
 45 * * * * /lfs/h2/emc/global/noscrub/emc.global/dump_archive/MONITOR/monitor_filecounts.sh > /lfs/h2/emc/stmp/emc.global/gda/logs/monitor_filecounts.log 2>&1
+###########################################################################
 
-#################
-# GFSv17 Retros #
-#################
+#################################
+# GFSv17 Retros
+#################################
+# POC: Jessica Meixner, Cathy Thomas and Ruiyu Sun
+#################### retrotestgfs01 ####################
 MAILTO="jessica.meixner@noaa.gov,catherine.thomas@noaa.gov,ruiyu.sun@noaa.gov,jiande.wang@noaa.gov,christian.boyer@noaa.gov,jiande.wang@noaa.gov"
 
 #realtime
@@ -44,8 +38,6 @@ MAILTO="jessica.meixner@noaa.gov,catherine.thomas@noaa.gov,ruiyu.sun@noaa.gov,ji
 */4 * * * * /apps/ops/test/nco/core/rocoto.v1.3.5/bin/rocotorun -d /lfs/h2/emc/gfstemp/emc.global/expdir/retrov17_01_stream2/retrov17_01_stream2.db -w /lfs/h2/emc/gfstemp/emc.global/expdir/retrov17_01_stream2/retrov17_01_stream2.xml

 */5 * * * * /apps/ops/test/nco/core/rocoto.v1.3.5/bin/rocotorun -d /lfs/h2/emc/gfstemp/emc.global/expdir/retrov17_01_stream3/retrov17_01_stream3.db -w /lfs/h2/emc/gfstemp/emc.global/expdir/retrov17_01_stream3/retrov17_01_stream3.xml

 
-
-
 #Experiment monitoring script
 
 MAILTO="catherine.thomas@noaa.gov"
@@ -62,22 +54,21 @@ MAILTO="jessica.meixner@noaa.gov"
 0 4 * * * /opt/pbs/bin/qsub < /lfs/h2/emc/gfstemp/emc.global/scripts/evsdownload/download4evs_stream4.sh
 
 
-# Check for production version of the GFS
-MAILTO="nicholas.esposito@noaa.gov,david.huber@noaa.gov,ashley.stanfield@noaa.gov"
-0 */12 * * * ls -d /lfs/h1/ops/prod/packages/gfs.*
-
-
-##### Sending ocean data to current production (Dogwood) from current dev (Cactus) 11/20/25 - Nick Esposito
+##### Sending ocean data to current production (Cactus) from current dev (Dogwood) 2/4/2026 - David Huber
 MAILTO="nicholas.esposito@noaa.gov"
 
 # These move ocean data between the prod and dev machines using rsync on a real time basis
*/15 * * * * /opt/pbs/bin/qsub -v year=`date -d "yesterday" +\%Y`,month=`date -d "yesterday" +\%m`,start_day=`date -d "yesterday" +\%d`,end_day=`date -d "yesterday" +\%d` < /u/emc.global/transfer_rsync_oceantoocean_thismachine.sh
*/15 * * * * /opt/pbs/bin/qsub -v year=`date -d "today" +\%Y`,month=`date -d "today" +\%m`,start_day=`date -d "today" +\%d`,end_day=`date -d "today" +\%d` < /u/emc.global/transfer_rsync_oceantoocean_thismachine.sh
*/15 * * * * /opt/pbs/bin/qsub -v year=`date -d "yesterday" +\%Y`,month=`date -d "yesterday" +\%m`,start_day=`date -d "yesterday" +\%d`,end_day=`date -d "yesterday" +\%d` < /u/emc.global/transfer_rsync_ocean_DtoC.sh
*/15 * * * * /opt/pbs/bin/qsub -v year=`date -d "today" +\%Y`,month=`date -d "today" +\%m`,start_day=`date -d "today" +\%d`,end_day=`date -d "today" +\%d` < /u/emc.global/transfer_rsync_ocean_DtoC.sh
 
 # For Mindo, sent on 20251224
 #15 * * * * /opt/pbs/bin/qsub -v year=`date -d "today" +\%Y`,month=`date -d "today" +\%m`,start_day=`date -d "today" +\%d`,end_day=`date -d "today" +\%d` < /u/emc.global/transfer_rsync_Mindo.sh
 
 # The next script is for rsyncing scripts between the prod and dev machines, a month at a time.
 #16 * * * * /opt/pbs/bin/qsub -v year=2022,month=08,start_day=14,end_day=31 < /u/emc.global/transfer_rsync_allfilesmonth.sh
+
+# Check for production version of the GFS
+MAILTO="nicholas.esposito@noaa.gov,david.huber@noaa.gov,ashley.stanfield@noaa.gov"
+#0 */12 * * * ls -d /lfs/h1/ops/prod/packages/gfs.*
```