### PR TITLE
Update GFS version to gfs.v16.3.31

### DIFF
--- a/GDA/gda/config.dumparch
+++ b/GDA/gda/config.dumparch
@@ -29,7 +29,7 @@ fi
 # Set account
 export USER=${USER:-emc.global}
 
-export gfs_ver="v16.3.30"
+export gfs_ver="v16.3.31"
 
 # Set GDA paths
 export DMPDIR="/lfs/h2/emc/dump/noscrub/dump"

--- a/GDA/gda/gda.xml
+++ b/GDA/gda/gda.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE workflow [
 
-  <!ENTITY gfs_ver "v16.3.30">
+  <!ENTITY gfs_ver "v16.3.31">
   <!ENTITY gfs_ver_com "v16.3">
   <!ENTITY obsproc_ver "v1.2">
   <!ENTITY rtofs_ver "v2.5">


### PR DESCRIPTION
Updates the gda.xml and gda.dumparch for the current version of GFS, which is v16.3.31

Updates two scripts:
GDA/gda/gda.xml
GDA/gda/config.dumparch